### PR TITLE
Cache statuses, dailys and search queries locally

### DIFF
--- a/models/status.js
+++ b/models/status.js
@@ -1,6 +1,7 @@
 import { AV } from '../leancloud/index';
 
 class Status extends AV.Object {
+
   get statusid () {
     return this.get('statusid')
   }
@@ -34,13 +35,13 @@ class Status extends AV.Object {
     return this.get('loginname')
   }
 
+  set msg (value) {
+    this.set('msg', value)
+  }
+
   get msg (){
     return this.get('msg')
   }
-
-  // get id () {
-  //   return this.get('id')
-  // }
 
   get avatar () {
     return this.get('avatar')

--- a/pages/calendar/index.js
+++ b/pages/calendar/index.js
@@ -44,7 +44,6 @@ Page({
 
   goToIndex (evt) {
     let entry = evt.currentTarget.dataset.entry;
-    console.log(`tap ${entry}`)
     wx.navigateTo({
       url: '/pages/list/index?entry=' + entry
     })

--- a/pages/detail/index.js
+++ b/pages/detail/index.js
@@ -17,8 +17,8 @@ Page({
 
     let condition = options && options.statusid
 
-    if ( condition ) {
-      store.fetch_status(options.statusid).then(status => {
+    if (condition) {
+      store.getStatus(options.statusid).then(status => {
         this.setData({
           'status': status 
         })

--- a/pages/index/index.js
+++ b/pages/index/index.js
@@ -24,7 +24,7 @@ Page({
     let app = getApp()
     let store = app.globalData.store
 
-    store.fetch_today().then(data => {
+    store.getToday().then(data => {
       this.setData({ 'statuses': data, 'hide_footer': false });
       if ( wx.hideLoading ) {
         setTimeout(() => wx.hideLoading(), 100)

--- a/pages/list/index.js
+++ b/pages/list/index.js
@@ -20,7 +20,9 @@ Page({
 
     let date = options.entry.replace(/\.daily/ig, '')
 
-    store.fetch_list(date).then(data => {
+    console.log(date)
+
+    store.getDaily(date).then(data => {
       this.setData({
        'date': date,
        'statuses': data,

--- a/pages/search/search.js
+++ b/pages/search/search.js
@@ -68,7 +68,7 @@ Page({
       duration: 0
     })
 
-    store.performSearch(keyword)
+    store.getQuery(keyword)
       .then(statuses => {
         this.setData({
           statuses: statuses.length

--- a/project.config.json
+++ b/project.config.json
@@ -39,7 +39,7 @@
 			"list": []
 		},
 		"miniprogram": {
-			"current": -1,
+			"current": 5,
 			"list": [
 				{
 					"id": 0,

--- a/store/api.js
+++ b/store/api.js
@@ -1,0 +1,71 @@
+import { AV } from '../leancloud/index'
+import Status from '../models/status'
+import Entries from '../models/entries'
+import transformer from '../utils/status.transformer'
+
+import {
+  generateRandom
+} from '../utils/index'
+
+export function fetchEntries () {
+  return new AV.Query(Entries).first()
+}
+
+export function fetchStatus (statusid) {
+  let query = new AV.Query(Status)
+    
+  query.equalTo('statusid', statusid)
+  query.limit(1)
+
+  return query.find().then(results => {
+    results[0].msg = transformer(results[0].msg)
+    return results[0]
+  }, err => {
+    console.log(err)
+  })
+}
+
+export function fetchDaily (date) {
+  let query = new AV.Query(Status);
+  
+  query.equalTo('date', date);
+  query.descending('createdAt');
+
+  return query.find().then(statuses => {
+    statuses = statuses.map(status => {
+      status.msg = transformer(status.msg)
+      return status
+    })
+    return statuses
+  })
+}
+
+export function search (query) {
+  let search = new AV.Query(Status);
+
+  search.contains('msg', query);
+  search.descending('createdAt');
+  search.limit(50);
+  
+  return search.find().then(statuses => {
+    statuses.forEach(status =>  {
+      status.set('msg', transformer(status.get('msg')))
+    })
+    return statuses
+  })
+}
+
+export function fetchRandom () {
+  let random = generateRandom()
+  let query = new AV.Query(Status)
+  query.skip(random);
+  query.limit(20);
+
+  return query.find().then(statuses => {
+    statuses.forEach(status => {
+      status.msg = transformer(status.get('msg'))
+    })
+    
+    return statuses
+  })
+}

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,0 +1,19 @@
+export function generateRandom () {
+  function skipRandom (step) {
+    Math.floor(Math.random() * Math.floor(step))
+  }
+
+  let randomArray = [
+    skipRandom(50),
+    skipRandom(500),
+    skipRandom(2000),
+    skipRandom(5000),
+    skipRandom(8000),
+    skipRandom(10000),
+    skipRandom(20000)
+  ]
+
+  return randomArray[
+    Math.floor(Math.random()*randomArray.length)
+  ]
+}


### PR DESCRIPTION
在本地缓存已获取的单条精选，每日精选和搜索结果：
```javascript
{
  entries: [],
  dailys: [],
  statuses: [],
  queries: []
}
```
上一个版本已经提交微信审核，还没有结果；这是一个 patch，尽可能减少不必要的多余请求数。

文件结构上做了修改，`Class Store {}` 不再负责 API 请求之类，单独拆分了一个 `.store/api.js`。
