### PR TITLE
fix: lifecycle problem

### DIFF
--- a/pages/calendar/index.js
+++ b/pages/calendar/index.js
@@ -1,27 +1,18 @@
-// pages/calendar/index.js
-Page({
+const app = getApp();
+const store = app.globalData.store;
 
-  /**
-   * 页面的初始数据
-   */
+Page({
   data: {
     store: null,
     calendars: [],
     hide_footer: true
   },
 
-  /**
-   * 生命周期函数--监听页面加载
-   */
-  onLoad: function (options) {
-
+  onShow () {
     wx.showLoading && wx.showLoading({
       title: "加载中...",
       mask: true
     });
-
-    let app = getApp();
-    let store = app.globalData.store;
 
     store.get_calendars().then(data => {
       this.setData({ 

--- a/pages/index/index.js
+++ b/pages/index/index.js
@@ -1,19 +1,20 @@
-// cache global store
-Page({
+const app = getApp()
+const store = app.globalData.store
 
-  /**
-   * 页面的初始数据
-   */
+Page({
   data: {
     today: null,
     statuses: [],
     hide_footer: true
   },
 
-  /**
-   * 生命周期函数--监听页面加载
-   */
   onLoad: function (options) {
+    
+  },
+
+  onReady: function () {},
+
+  onShow: function () {
     if (wx.showLoading) {
       wx.showLoading({
         title: "加载中...",
@@ -21,22 +22,16 @@ Page({
       })
     }
 
-    let app = getApp()
-    let store = app.globalData.store
-
     store.getToday().then(data => {
-      this.setData({ 'statuses': data, 'hide_footer': false });
+      this.setData({ 
+        'statuses': data, 
+        'hide_footer': false 
+      });
+      
       if ( wx.hideLoading ) {
         setTimeout(() => wx.hideLoading(), 100)
       }
     })
-  },
-
-  /*** 生命周期函数--监听页面初次渲染完成 */
-  onReady: function () {},
-
-  /*** 生命周期函数--监听页面显示 */
-  onShow: function () {
   },
 
   /**

--- a/pages/list/index.js
+++ b/pages/list/index.js
@@ -1,4 +1,6 @@
-// pages/list/index.js
+const app = getApp();
+const store = app.globalData.store;
+
 Page({
   data: {
     date: null,
@@ -7,10 +9,12 @@ Page({
   },
 
   onLoad: function (options) {
-    let app = getApp();
-    let store = app.globalData.store;
-    let entry = options.entry;
+    this.setData({
+      date: options.entry.replace(/\.daily/ig, '')
+    })
+  },
 
+  onShow () {
     if (wx.showLoading) {
       wx.showLoading({
         title: "加载中...",
@@ -18,14 +22,9 @@ Page({
       })
     }
 
-    let date = options.entry.replace(/\.daily/ig, '')
-
-    console.log(date)
-
-    store.getDaily(date).then(data => {
+    store.getDaily(this.data.date).then(statuses => {
       this.setData({
-       'date': date,
-       'statuses': data,
+       'statuses': statuses,
        'hide_footer': false
       })
 

--- a/pages/search/search.js
+++ b/pages/search/search.js
@@ -13,14 +13,20 @@ Page({
   },
 
   onLoad (options) {
-    if (options && options.keyword) {
-      this.search(options.keyword)
-    }
+   if (options && options.keyword) {
+     this.setData({
+       keyword: options.keyword
+     })
+   }
   },
 
   onShow () {
     // this.isCurrentPage = true;
     // wx.onAccelerometerChange(this.onDiviceShake)
+
+    if (this.data.keyword) {
+      this.search(this.data.keyword)
+    }
   },
 
   onHide: function () {

--- a/project.config.json
+++ b/project.config.json
@@ -39,7 +39,7 @@
 			"list": []
 		},
 		"miniprogram": {
-			"current": 5,
+			"current": 1,
 			"list": [
 				{
 					"id": 0,


### PR DESCRIPTION
解决：
当非常快速的在页面之间切换，尤其是首页的三个 tab 来回点击，当前 tab `onLoad()` 中的 `request()` 方法在切换到别的 tab 后会直接被 terminated，如果当前 `request()` 没有在 terminated 之前有成功返回，那么下一次再进入当前 tab 就不会再次发出请求。

所以修改成 `onShow()` 中调用 `request()`，保证每次都触发抓取。